### PR TITLE
MQTT サブスクライブ時のエラーハンドリング条件を広げた

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -113,9 +113,9 @@ function run () {
         console.error('[!] "granted" is undefined. Failed to subscribe.')
         process.exit(-1)
       }
-      
+
       const g = granted[0]
-      if (!g.topic) {
+      if (!g?.topic) {
         // TODO: find why this occurs
         console.error('[!] "topic" is undefined. Failed to subscribe.')
         process.exit(-1)

--- a/index.ts
+++ b/index.ts
@@ -113,6 +113,10 @@ function run () {
         console.error('[!] "granted" is undefined. Failed to subscribe.')
         process.exit(-1)
       }
+      if (!Array.isArray(granted) || granted.length === 0) {
+        console.error('[!] "granted" is not an array or it has no element. "granted":', granted)
+        process.exit(-1)
+      }
 
       const g = granted[0]
       if (!g?.topic) {
@@ -120,7 +124,7 @@ function run () {
         console.error('[!] "topic" is undefined. Failed to subscribe.')
         process.exit(-1)
       }
-      
+
       const t = g.topic.split('/')
       if (t.length === 2) {
         console.log('Subscribed to')


### PR DESCRIPTION
タイトルの通りです．Beebotteにサブスクライブした際のエラーをなるべく拾うようにしました．根本的な解決にはなってません．